### PR TITLE
fix README.md mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All done with setup.
 
 ### Place new font files
 
-Place a font file, hypothetically called 'FooBar-Book.ttf', into /meshwriter/fonts.&nbsp;
+Place a font file, hypothetically called 'FooBar-Book.ttf', into /meshwriter-font/fonts.&nbsp;
 
 ### Select glyph coverage
 


### PR DESCRIPTION
I just tried to generate foo-font.js, and I found the readme.md that had a mistake.